### PR TITLE
Separate node declarations and resolved nodes

### DIFF
--- a/DIKit.xcodeproj/project.pbxproj
+++ b/DIKit.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		7F540C8B1F73F1970045CC12 /* MethodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C8A1F73F1970045CC12 /* MethodTests.swift */; };
 		7F540C8D1F73F2210045CC12 /* PropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C8C1F73F2210045CC12 /* PropertyTests.swift */; };
 		7F540C8F1F73F5340045CC12 /* TypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C8E1F73F5340045CC12 /* TypeTests.swift */; };
+		7F540C951F740C930045CC12 /* InitializerInjectableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C931F740C210045CC12 /* InitializerInjectableType.swift */; };
+		7F540C981F740FD10045CC12 /* InitializerInjectableTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C971F740FD10045CC12 /* InitializerInjectableTypeTests.swift */; };
 		OBJ_155 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_161 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* Package.swift */; };
 		OBJ_167 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_54 /* Package.swift */; };
@@ -411,6 +413,8 @@
 		7F540C8A1F73F1970045CC12 /* MethodTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MethodTests.swift; sourceTree = "<group>"; };
 		7F540C8C1F73F2210045CC12 /* PropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyTests.swift; sourceTree = "<group>"; };
 		7F540C8E1F73F5340045CC12 /* TypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeTests.swift; sourceTree = "<group>"; };
+		7F540C931F740C210045CC12 /* InitializerInjectableType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitializerInjectableType.swift; sourceTree = "<group>"; };
+		7F540C971F740FD10045CC12 /* InitializerInjectableTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitializerInjectableTypeTests.swift; sourceTree = "<group>"; };
 		"DIKit::DIGenKit::Product" /* DIGenKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DIGenKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"DIKit::DIGenKitTests::Product" /* DIGenKitTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = DIGenKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		"DIKit::DIKit::Product" /* DIKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DIKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -656,6 +660,14 @@
 			path = Structure;
 			sourceTree = "<group>";
 		};
+		7F540C961F740FD10045CC12 /* Graph */ = {
+			isa = PBXGroup;
+			children = (
+				7F540C971F740FD10045CC12 /* InitializerInjectableTypeTests.swift */,
+			);
+			path = Graph;
+			sourceTree = "<group>";
+		};
 		OBJ_102 /* sourcekitten */ = {
 			isa = PBXGroup;
 			children = (
@@ -786,6 +798,7 @@
 				OBJ_17 /* ResolveMethod.swift */,
 				OBJ_18 /* Node.swift */,
 				OBJ_19 /* Resolver.swift */,
+				7F540C931F740C210045CC12 /* InitializerInjectableType.swift */,
 			);
 			path = Graph;
 			sourceTree = "<group>";
@@ -822,6 +835,7 @@
 			children = (
 				OBJ_30 /* ABCDTests.swift */,
 				7F3C5B0D1F6D701A00842641 /* AppTests.swift */,
+				7F540C961F740FD10045CC12 /* Graph */,
 				7F540C891F73F1970045CC12 /* Structure */,
 			);
 			name = DIGenKitTests;
@@ -1396,6 +1410,7 @@
 				7F540C8F1F73F5340045CC12 /* TypeTests.swift in Sources */,
 				OBJ_197 /* ABCDTests.swift in Sources */,
 				7F3C5B0F1F6D707700842641 /* AppTests.swift in Sources */,
+				7F540C981F740FD10045CC12 /* InitializerInjectableTypeTests.swift in Sources */,
 				7F540C8D1F73F2210045CC12 /* PropertyTests.swift in Sources */,
 				7F540C8B1F73F1970045CC12 /* MethodTests.swift in Sources */,
 			);
@@ -1414,6 +1429,7 @@
 			buildActionMask = 0;
 			files = (
 				OBJ_256 /* CodeGenerator.swift in Sources */,
+				7F540C951F740C930045CC12 /* InitializerInjectableType.swift in Sources */,
 				OBJ_257 /* String+Name.swift in Sources */,
 				OBJ_258 /* Structure+Property.swift in Sources */,
 				OBJ_259 /* ResolveMethod.swift in Sources */,

--- a/DIKit.xcodeproj/project.pbxproj
+++ b/DIKit.xcodeproj/project.pbxproj
@@ -806,8 +806,8 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_17 /* ResolveMethod.swift */,
-				OBJ_18 /* Node.swift */,
 				OBJ_19 /* Resolver.swift */,
+				OBJ_18 /* Node.swift */,
 				7F540C931F740C210045CC12 /* InitializerInjectableType.swift */,
 				7F540C991F7412E80045CC12 /* FactoryMethodInjectableType.swift */,
 				7F540C9D1F7414A30045CC12 /* ProviderMethod.swift */,

--- a/DIKit.xcodeproj/project.pbxproj
+++ b/DIKit.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		7F540C8F1F73F5340045CC12 /* TypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C8E1F73F5340045CC12 /* TypeTests.swift */; };
 		7F540C951F740C930045CC12 /* InitializerInjectableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C931F740C210045CC12 /* InitializerInjectableType.swift */; };
 		7F540C981F740FD10045CC12 /* InitializerInjectableTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C971F740FD10045CC12 /* InitializerInjectableTypeTests.swift */; };
+		7F540C9A1F7412E80045CC12 /* FactoryMethodInjectableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C991F7412E80045CC12 /* FactoryMethodInjectableType.swift */; };
+		7F540C9C1F7413A70045CC12 /* FactoryMethodInjectableTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C9B1F7413A70045CC12 /* FactoryMethodInjectableTypeTests.swift */; };
 		OBJ_155 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_161 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* Package.swift */; };
 		OBJ_167 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_54 /* Package.swift */; };
@@ -415,6 +417,8 @@
 		7F540C8E1F73F5340045CC12 /* TypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeTests.swift; sourceTree = "<group>"; };
 		7F540C931F740C210045CC12 /* InitializerInjectableType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitializerInjectableType.swift; sourceTree = "<group>"; };
 		7F540C971F740FD10045CC12 /* InitializerInjectableTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitializerInjectableTypeTests.swift; sourceTree = "<group>"; };
+		7F540C991F7412E80045CC12 /* FactoryMethodInjectableType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactoryMethodInjectableType.swift; sourceTree = "<group>"; };
+		7F540C9B1F7413A70045CC12 /* FactoryMethodInjectableTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactoryMethodInjectableTypeTests.swift; sourceTree = "<group>"; };
 		"DIKit::DIGenKit::Product" /* DIGenKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DIGenKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"DIKit::DIGenKitTests::Product" /* DIGenKitTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = DIGenKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		"DIKit::DIKit::Product" /* DIKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DIKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -664,6 +668,7 @@
 			isa = PBXGroup;
 			children = (
 				7F540C971F740FD10045CC12 /* InitializerInjectableTypeTests.swift */,
+				7F540C9B1F7413A70045CC12 /* FactoryMethodInjectableTypeTests.swift */,
 			);
 			path = Graph;
 			sourceTree = "<group>";
@@ -799,6 +804,7 @@
 				OBJ_18 /* Node.swift */,
 				OBJ_19 /* Resolver.swift */,
 				7F540C931F740C210045CC12 /* InitializerInjectableType.swift */,
+				7F540C991F7412E80045CC12 /* FactoryMethodInjectableType.swift */,
 			);
 			path = Graph;
 			sourceTree = "<group>";
@@ -1411,6 +1417,7 @@
 				OBJ_197 /* ABCDTests.swift in Sources */,
 				7F3C5B0F1F6D707700842641 /* AppTests.swift in Sources */,
 				7F540C981F740FD10045CC12 /* InitializerInjectableTypeTests.swift in Sources */,
+				7F540C9C1F7413A70045CC12 /* FactoryMethodInjectableTypeTests.swift in Sources */,
 				7F540C8D1F73F2210045CC12 /* PropertyTests.swift in Sources */,
 				7F540C8B1F73F1970045CC12 /* MethodTests.swift in Sources */,
 			);
@@ -1438,6 +1445,7 @@
 				OBJ_263 /* Method.swift in Sources */,
 				OBJ_264 /* Property.swift in Sources */,
 				OBJ_265 /* Type.swift in Sources */,
+				7F540C9A1F7412E80045CC12 /* FactoryMethodInjectableType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DIKit.xcodeproj/project.pbxproj
+++ b/DIKit.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		7F540C981F740FD10045CC12 /* InitializerInjectableTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C971F740FD10045CC12 /* InitializerInjectableTypeTests.swift */; };
 		7F540C9A1F7412E80045CC12 /* FactoryMethodInjectableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C991F7412E80045CC12 /* FactoryMethodInjectableType.swift */; };
 		7F540C9C1F7413A70045CC12 /* FactoryMethodInjectableTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C9B1F7413A70045CC12 /* FactoryMethodInjectableTypeTests.swift */; };
+		7F540C9E1F7414A30045CC12 /* ProviderMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C9D1F7414A30045CC12 /* ProviderMethod.swift */; };
+		7F540CA01F7416360045CC12 /* ProviderMethodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C9F1F7416360045CC12 /* ProviderMethodTests.swift */; };
 		OBJ_155 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_161 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* Package.swift */; };
 		OBJ_167 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_54 /* Package.swift */; };
@@ -419,6 +421,8 @@
 		7F540C971F740FD10045CC12 /* InitializerInjectableTypeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitializerInjectableTypeTests.swift; sourceTree = "<group>"; };
 		7F540C991F7412E80045CC12 /* FactoryMethodInjectableType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactoryMethodInjectableType.swift; sourceTree = "<group>"; };
 		7F540C9B1F7413A70045CC12 /* FactoryMethodInjectableTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactoryMethodInjectableTypeTests.swift; sourceTree = "<group>"; };
+		7F540C9D1F7414A30045CC12 /* ProviderMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderMethod.swift; sourceTree = "<group>"; };
+		7F540C9F1F7416360045CC12 /* ProviderMethodTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderMethodTests.swift; sourceTree = "<group>"; };
 		"DIKit::DIGenKit::Product" /* DIGenKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DIGenKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"DIKit::DIGenKitTests::Product" /* DIGenKitTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = DIGenKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		"DIKit::DIKit::Product" /* DIKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = DIKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -669,6 +673,7 @@
 			children = (
 				7F540C971F740FD10045CC12 /* InitializerInjectableTypeTests.swift */,
 				7F540C9B1F7413A70045CC12 /* FactoryMethodInjectableTypeTests.swift */,
+				7F540C9F1F7416360045CC12 /* ProviderMethodTests.swift */,
 			);
 			path = Graph;
 			sourceTree = "<group>";
@@ -805,6 +810,7 @@
 				OBJ_19 /* Resolver.swift */,
 				7F540C931F740C210045CC12 /* InitializerInjectableType.swift */,
 				7F540C991F7412E80045CC12 /* FactoryMethodInjectableType.swift */,
+				7F540C9D1F7414A30045CC12 /* ProviderMethod.swift */,
 			);
 			path = Graph;
 			sourceTree = "<group>";
@@ -1416,6 +1422,7 @@
 				7F540C8F1F73F5340045CC12 /* TypeTests.swift in Sources */,
 				OBJ_197 /* ABCDTests.swift in Sources */,
 				7F3C5B0F1F6D707700842641 /* AppTests.swift in Sources */,
+				7F540CA01F7416360045CC12 /* ProviderMethodTests.swift in Sources */,
 				7F540C981F740FD10045CC12 /* InitializerInjectableTypeTests.swift in Sources */,
 				7F540C9C1F7413A70045CC12 /* FactoryMethodInjectableTypeTests.swift in Sources */,
 				7F540C8D1F73F2210045CC12 /* PropertyTests.swift in Sources */,
@@ -1446,6 +1453,7 @@
 				OBJ_264 /* Property.swift in Sources */,
 				OBJ_265 /* Type.swift in Sources */,
 				7F540C9A1F7412E80045CC12 /* FactoryMethodInjectableType.swift in Sources */,
+				7F540C9E1F7414A30045CC12 /* ProviderMethod.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/DIGenKit/CodeGenerator.swift
+++ b/Sources/DIGenKit/CodeGenerator.swift
@@ -21,12 +21,7 @@ public final class CodeGenerator {
             }
             .joined())
 
-        let injectableTypeNodes = types.flatMap(Node.init(injectableType:))
-        let factoryMethodInjectableTypeNods = types.flatMap(Node.init(factoryMethodInjectableType:))
-        let resolvers = types.flatMap {
-            return Resolver(type: $0, injectableTypeNodes: injectableTypeNodes + factoryMethodInjectableTypeNods )
-
-        }
+        let resolvers = types.flatMap { Resolver(type: $0, allTypes: types) }
         context = ["resolvers": resolvers]
     }
 

--- a/Sources/DIGenKit/Graph/FactoryMethodInjectableType.swift
+++ b/Sources/DIGenKit/Graph/FactoryMethodInjectableType.swift
@@ -31,7 +31,7 @@ struct FactoryMethodInjectableType {
 
         guard
             let factoryMethod = type.methods.filter({ $0.name == "makeInstance(dependency:)" }).first, factoryMethod.isStatic,
-            let parameter = factoryMethod.parameters.first, parameter.typeName == "Dependency" else {
+            let parameter = factoryMethod.parameters.first, parameter.typeName == "Dependency" || parameter.typeName == "\(type.name).Dependency" else {
             // Static factory method 'makeInstance(dependency:)' declared in 'FactoryMethodInjectable' is not found.
             return nil
         }

--- a/Sources/DIGenKit/Graph/FactoryMethodInjectableType.swift
+++ b/Sources/DIGenKit/Graph/FactoryMethodInjectableType.swift
@@ -1,0 +1,42 @@
+//
+//  FactoryMethodInjectableType.swift
+//  DIGenKit
+//
+//  Created by Yosuke Ishikawa on 2017/09/22.
+//
+
+import Foundation
+
+struct FactoryMethodInjectableType {
+    let name: String
+    let dependencyProperties: [Property]
+
+    init?(type: Type) {
+        guard
+            type.inheritedTypeNames.contains("FactoryMethodInjectable") ||
+            type.inheritedTypeNames.contains("DIKit.FactoryMethodInjectable") else {
+            // Type is not declared as conformer of 'FactoryMethodInjectable'.
+            return nil
+        }
+
+        guard let dependencyType = type.nestedTypes.filter({ $0.name == "Dependency" }).first else {
+            // Associated type 'Dependency' declared in 'FactoryMethodInjectable' is not found.
+            return nil
+        }
+
+        guard dependencyType.kind == .struct else {
+            // Associated type 'Dependency' must be a struct.
+            return nil
+        }
+
+        guard
+            let factoryMethod = type.methods.filter({ $0.name == "makeInstance(dependency:)" }).first, factoryMethod.isStatic,
+            let parameter = factoryMethod.parameters.first, parameter.typeName == "Dependency" else {
+            // Static factory method 'makeInstance(dependency:)' declared in 'FactoryMethodInjectable' is not found.
+            return nil
+        }
+
+        name = type.name
+        dependencyProperties = dependencyType.properties.filter { !$0.isStatic }
+    }
+}

--- a/Sources/DIGenKit/Graph/InitializerInjectableType.swift
+++ b/Sources/DIGenKit/Graph/InitializerInjectableType.swift
@@ -1,0 +1,42 @@
+//
+//  InitializerInjectableType.swift
+//  DIGenKitTests
+//
+//  Created by Yosuke Ishikawa on 2017/09/22.
+//
+
+import Foundation
+
+struct InitializerInjectableType {
+    let name: String
+    let dependencyProperties: [Property]
+
+    init?(type: Type) {
+        guard
+            type.inheritedTypeNames.contains("Injectable") ||
+            type.inheritedTypeNames.contains("DIKit.Injectable") else {
+            // Type is not declared as conformer of Injectable.
+            return nil
+        }
+
+        guard let dependencyType = type.nestedTypes.filter({ $0.name == "Dependency" }).first else {
+            // Associated type 'Dependency' declared in 'Injectable' is not found.
+            return nil
+        }
+
+        guard dependencyType.kind == .struct else {
+            // Associated type 'Dependency' must be a struct.
+            return nil
+        }
+
+        guard
+            let initializer = type.methods.filter({ $0.name == "init(dependency:)" }).first,
+            let parameter = initializer.parameters.first, parameter.typeName == "Dependency" else {
+            // Initializer 'init(dependency:)' declared in 'Injectable' is not found.
+            return nil
+        }
+
+        name = type.name
+        dependencyProperties = dependencyType.properties.filter { !$0.isStatic }
+    }
+}

--- a/Sources/DIGenKit/Graph/Node.swift
+++ b/Sources/DIGenKit/Graph/Node.swift
@@ -5,35 +5,109 @@
 //  Created by Yosuke Ishikawa on 2017/09/15.
 //
 
-enum Node {
-    case initializerInjectableType(InitializerInjectableType)
-    case factoryMethodInjectableType(FactoryMethodInjectableType)
-    case providerMethod(ProviderMethod)
+struct Node {
+    enum Declaration {
+        case initializerInjectableType(InitializerInjectableType)
+        case factoryMethodInjectableType(FactoryMethodInjectableType)
+        case providerMethod(ProviderMethod)
 
-    struct Dependency {
+        struct Dependency {
+            let name: String
+            let typeName: String
+        }
+
+        var typeName: String {
+            switch self {
+            case .initializerInjectableType(let type):
+                return type.name
+            case .factoryMethodInjectableType(let type):
+                return type.name
+            case .providerMethod(let method):
+                return method.returnTypeName
+            }
+        }
+
+        var dependencies: [Dependency] {
+            switch self {
+            case .initializerInjectableType(let type):
+                return type.dependencyProperties.map { Dependency(name: $0.name, typeName: $0.typeName) }
+            case .factoryMethodInjectableType(let type):
+                return type.dependencyProperties.map { Dependency(name: $0.name, typeName: $0.typeName) }
+            case .providerMethod(let method):
+                return method.parameters.map { Dependency(name: $0.name, typeName: $0.typeName) }
+            }
+        }
+    }
+
+    struct Parameter {
         let name: String
         let typeName: String
     }
 
-    var typeName: String {
-        switch self {
-        case .initializerInjectableType(let type):
-            return type.name
-        case .factoryMethodInjectableType(let type):
-            return type.name
-        case .providerMethod(let method):
-            return method.returnTypeName
+    enum Dependency {
+        case node(name: String, node: Node)
+        case parameter(Parameter)
+    }
+
+    let declaration: Declaration
+    let dependencies: [Dependency]
+
+    init?(declaration: Declaration, allDeclarations: [Declaration], availableNodes: [Node]) {
+        self.declaration = declaration
+        self.dependencies = declaration.dependencies
+            .flatMap { dependency -> Dependency? in
+                let declarationTypeNames = allDeclarations.map { $0.typeName }
+                if let resolvableNode = availableNodes.filter({ $0.declaration.typeName == dependency.typeName }).first {
+                    return .node(name: dependency.name, node: resolvableNode)
+                } else if !declarationTypeNames.contains(dependency.typeName) {
+                    return .parameter(Parameter(name: dependency.name, typeName: dependency.typeName))
+                } else {
+                    return nil
+                }
+            }
+
+        if dependencies.count != declaration.dependencies.count {
+            // Could not fulfill all dependencies
+            return nil
         }
     }
 
-    var dependencies: [Dependency] {
-        switch self {
-        case .initializerInjectableType(let type):
-            return type.dependencyProperties.map { Dependency(name: $0.name, typeName: $0.typeName) }
-        case .factoryMethodInjectableType(let type):
-            return type.dependencyProperties.map { Dependency(name: $0.name, typeName: $0.typeName) }
-        case .providerMethod(let method):
-            return method.parameters.map { Dependency(name: $0.name, typeName: $0.typeName) }
-        }
+    var shallowDependencyNodes: [Node] {
+        return dependencies
+            .flatMap { dependency -> Node? in
+                if case .node(_, let node) = dependency {
+                    return node
+                } else {
+                    return nil
+                }
+            }
+    }
+
+    var deepDependencyParameters: [Parameter] {
+        return Node.recursiveDependencyParameters(of: self)
+    }
+
+    static func recursiveDependencyParameters(of node: Node) -> [Parameter] {
+        let dependencyNodes = node.dependencies
+            .flatMap { dependency -> Node? in
+                if case .node(_, let node) = dependency {
+                    return node
+                } else {
+                    return nil
+                }
+            }
+
+        let dependencyParameter = node.dependencies
+            .flatMap { dependency -> Parameter? in
+                if case .parameter(let parameter) = dependency {
+                    return parameter
+                } else {
+                    return nil
+                }
+            }
+
+        let inheritedParameters = Array(dependencyNodes.map({ Node.recursiveDependencyParameters(of: $0) }).joined())
+
+        return dependencyParameter + inheritedParameters
     }
 }

--- a/Sources/DIGenKit/Graph/Node.swift
+++ b/Sources/DIGenKit/Graph/Node.swift
@@ -5,72 +5,35 @@
 //  Created by Yosuke Ishikawa on 2017/09/15.
 //
 
-struct Node {
-    enum Kind {
-        case initializer
-        case factoryMethod
-        case providerMethod
-    }
+enum Node {
+    case initializerInjectableType(InitializerInjectableType)
+    case factoryMethodInjectableType(FactoryMethodInjectableType)
+    case providerMethod(ProviderMethod)
 
     struct Dependency {
         let name: String
         let typeName: String
     }
 
-    let kind: Kind
-    let typeName: String
-    let dependencies: [Dependency]
-    let instantiatingFunction: Method
-
-    init?(injectableType: Type) {
-        guard
-            let initializer = injectableType.methods.filter({ $0.name == "init(dependency:)" }).first,
-            injectableType.inheritedTypeNames.contains("Injectable") ||
-            injectableType.inheritedTypeNames.contains("DIKit.Injectable") else {
-            return nil
+    var typeName: String {
+        switch self {
+        case .initializerInjectableType(let type):
+            return type.name
+        case .factoryMethodInjectableType(let type):
+            return type.name
+        case .providerMethod(let method):
+            return method.returnTypeName
         }
-
-        let properties = Array(injectableType.nestedTypes
-            .filter { $0.name == "Dependency" }
-            .map { $0.properties.filter { !$0.isStatic } }
-            .joined())
-
-        kind = .initializer
-        typeName = injectableType.name
-        dependencies = properties.map { Dependency(name: $0.name, typeName: $0.typeName) }
-        instantiatingFunction = initializer
     }
 
-    init?(factoryMethodInjectableType type: Type) {
-        guard
-            let factoryMethod = type.methods.filter({ $0.name == "makeInstance(dependency:)" }).first,
-            factoryMethod.isStatic,
-            type.inheritedTypeNames.contains("FactoryMethodInjectable") ||
-            type.inheritedTypeNames.contains("DIKit.FactoryMethodInjectable") else {
-            return nil
+    var dependencies: [Dependency] {
+        switch self {
+        case .initializerInjectableType(let type):
+            return type.dependencyProperties.map { Dependency(name: $0.name, typeName: $0.typeName) }
+        case .factoryMethodInjectableType(let type):
+            return type.dependencyProperties.map { Dependency(name: $0.name, typeName: $0.typeName) }
+        case .providerMethod(let method):
+            return method.parameters.map { Dependency(name: $0.name, typeName: $0.typeName) }
         }
-
-        let properties = Array(type.nestedTypes
-            .filter { $0.name == "Dependency" }
-            .map { $0.properties.filter { !$0.isStatic } }
-            .joined())
-
-        kind = .factoryMethod
-        typeName = type.name
-        dependencies = properties.map { Dependency(name: $0.name, typeName: $0.typeName) }
-        instantiatingFunction = factoryMethod
-    }
-
-    init?(providerMethod: Method) {
-        guard
-            providerMethod.name.hasPrefix("provide"),
-            providerMethod.returnTypeName != "Void" else {
-            return nil
-        }
-
-        kind = .providerMethod
-        typeName = providerMethod.returnTypeName
-        dependencies = providerMethod.parameters.map { Dependency(name: $0.name, typeName: $0.typeName) }
-        instantiatingFunction = providerMethod
     }
 }

--- a/Sources/DIGenKit/Graph/ProviderMethod.swift
+++ b/Sources/DIGenKit/Graph/ProviderMethod.swift
@@ -1,0 +1,51 @@
+//
+//  ProviderMethod.swift
+//  DIGenKit
+//
+//  Created by Yosuke Ishikawa on 2017/09/22.
+//
+
+import Foundation
+
+struct ProviderMethod {
+    let name: String
+    let returnTypeName: String
+    let parameters: [Method.Parameter]
+
+    private init?(method: Method) {
+        guard method.name.hasPrefix("provide") else {
+            // Provide method must have 'provide' prefix.
+            return nil
+        }
+
+        guard method.returnTypeName != "Void" else {
+            // Provide method must return non-void type.
+            return nil
+        }
+
+        guard !method.isStatic else {
+            // Provide method must not be static.
+            return nil
+        }
+
+        guard !method.isInitializer else {
+            // Provide method must not be an initalizer.
+            return nil
+        }
+
+        name = method.name
+        returnTypeName = method.returnTypeName
+        parameters = method.parameters
+    }
+    
+    static func providerMethods(inResoverType type: Type) -> [ProviderMethod] {
+        guard 
+            type.inheritedTypeNames.contains("Resolver") ||
+            type.inheritedTypeNames.contains("DIKit.Resolver") else {
+            // Type does not conform to 'Resolver' protocol.
+            return []
+        }
+        
+        return type.methods.flatMap(ProviderMethod.init(method:))
+    }
+}

--- a/Sources/DIGenKit/Graph/ProviderMethod.swift
+++ b/Sources/DIGenKit/Graph/ProviderMethod.swift
@@ -38,7 +38,7 @@ struct ProviderMethod {
         parameters = method.parameters
     }
     
-    static func providerMethods(inResoverType type: Type) -> [ProviderMethod] {
+    static func providerMethods(inResolverType type: Type) -> [ProviderMethod] {
         guard 
             type.inheritedTypeNames.contains("Resolver") ||
             type.inheritedTypeNames.contains("DIKit.Resolver") else {

--- a/Sources/DIGenKit/Graph/ProviderMethod.swift
+++ b/Sources/DIGenKit/Graph/ProviderMethod.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct ProviderMethod {
-    let name: String
+    let nameWithoutParameters: String
     let returnTypeName: String
     let parameters: [Method.Parameter]
 
@@ -33,7 +33,7 @@ struct ProviderMethod {
             return nil
         }
 
-        name = method.name
+        nameWithoutParameters = method.nameWithoutParameters
         returnTypeName = method.returnTypeName
         parameters = method.parameters
     }

--- a/Sources/DIGenKit/Graph/ResolveMethod.swift
+++ b/Sources/DIGenKit/Graph/ResolveMethod.swift
@@ -54,15 +54,14 @@ struct ResolveMethod {
             }
             .joined(separator: ", ")
 
-        let functionName = node.instantiatingFunction.nameWithoutParameters
         let selfInstantiationCode: String
-        switch node.kind {
-        case .initializer:
-            selfInstantiationCode = "return \(node.typeName)(dependency: .init(\(selfInstantiationParameters)))"
-        case .factoryMethod:
-            selfInstantiationCode = "return \(node.typeName).makeInstance(dependency: .init(\(selfInstantiationParameters)))"
-        case .providerMethod:
-            selfInstantiationCode = "return \(functionName)(\(selfInstantiationParameters))"
+        switch node {
+        case .initializerInjectableType(let type):
+            selfInstantiationCode = "return \(type.name)(dependency: .init(\(selfInstantiationParameters)))"
+        case .factoryMethodInjectableType(let type):
+            selfInstantiationCode = "return \(type.name).makeInstance(dependency: .init(\(selfInstantiationParameters)))"
+        case .providerMethod(let method):
+            selfInstantiationCode = "return \(method.nameWithoutParameters)(\(selfInstantiationParameters))"
         }
 
         bodyLines = [dependencyInstantiation, selfInstantiationCode]

--- a/Sources/DIGenKit/Graph/Resolver.swift
+++ b/Sources/DIGenKit/Graph/Resolver.swift
@@ -25,7 +25,7 @@ struct Resolver {
             .map { Node.factoryMethodInjectableType($0) }
 
         let providerMethods = ProviderMethod
-            .providerMethods(inResoverType: type)
+            .providerMethods(inResolverType: type)
             .map { Node.providerMethod($0) }
 
         let allNodes = initializerInjectableTypes + factoryMethodInjectableTypes + providerMethods

--- a/Tests/DIGenKitTests/Graph/FactoryMethodInjectableTypeTests.swift
+++ b/Tests/DIGenKitTests/Graph/FactoryMethodInjectableTypeTests.swift
@@ -1,0 +1,137 @@
+//
+//  FactoryMethodInjectableTypeTests.swift
+//  DIGenKitTests
+//
+//  Created by Yosuke Ishikawa on 2017/09/22.
+//
+
+import Foundation
+import XCTest
+import SourceKittenFramework
+
+@testable import DIGenKit
+
+final class FactoryMethodInjectableTypeTests: XCTestCase {
+    func test() {
+        let code = """
+            struct Test: FactoryMethodInjectable {
+                struct Dependency {
+                    let a: A
+                    let b: B
+                }
+
+                static func makeInstance(dependency: Dependency) {
+                    return Test()
+                }
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = FactoryMethodInjectableType(type: type)
+        XCTAssertEqual(injectableType?.name, "Test")
+        XCTAssertEqual(injectableType?.dependencyProperties.count, 2)
+        XCTAssertEqual(injectableType?.dependencyProperties[0].name, "a")
+        XCTAssertEqual(injectableType?.dependencyProperties[0].typeName, "A")
+        XCTAssertEqual(injectableType?.dependencyProperties[1].name, "b")
+        XCTAssertEqual(injectableType?.dependencyProperties[1].typeName, "B")
+    }
+
+    func testNonInjectableType() {
+        let code = """
+            struct Test {
+                struct Dependency {
+                    let a: A
+                    let b: B
+                }
+
+                static func makeInstance(dependency: Dependency) {
+                    return Test()
+                }
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = FactoryMethodInjectableType(type: type)
+        XCTAssertNil(injectableType)
+    }
+
+    func testClassAssociatedType() {
+        let code = """
+            struct Test: FactoryMethodInjectable {
+                class Dependency {
+                    let a: A
+                    let b: B
+                }
+
+                static func makeInstance(dependency: Dependency) {
+                    return Test()
+                }
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = FactoryMethodInjectableType(type: type)
+        XCTAssertNil(injectableType)
+    }
+
+    func testMissingAssociatedType() {
+        let code = """
+            struct Test: FactoryMethodInjectable {
+                static func makeInstance(dependency: Dependency) {
+                    return Test()
+                }
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = FactoryMethodInjectableType(type: type)
+        XCTAssertNil(injectableType)
+    }
+
+    func testMissingFactoryMethod() {
+        let code = """
+            struct Test: FactoryMethodInjectable {
+                struct Dependency {
+                    let a: A
+                    let b: B
+                }
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = FactoryMethodInjectableType(type: type)
+        XCTAssertNil(injectableType)
+    }
+
+    func testWrongTypeFactoryMethod() {
+        let code = """
+            struct Test: FactoryMethodInjectable {
+                struct Dependency {
+                    let a: A
+                    let b: B
+                }
+
+                static func makeInstance(dependency: A) {
+                    return Test()
+                }
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = FactoryMethodInjectableType(type: type)
+        XCTAssertNil(injectableType)
+    }
+}
+

--- a/Tests/DIGenKitTests/Graph/InitializerInjectableTypeTests.swift
+++ b/Tests/DIGenKitTests/Graph/InitializerInjectableTypeTests.swift
@@ -1,0 +1,126 @@
+//
+//  InitializerInjectableTypeTests.swift
+//  DIGenKitTests
+//
+//  Created by Yosuke Ishikawa on 2017/09/21.
+//
+
+import Foundation
+import XCTest
+import SourceKittenFramework
+
+@testable import DIGenKit
+
+final class InitializerInjectableTypeTests: XCTestCase {
+    func test() {
+        let code = """
+            struct Test: Injectable {
+                struct Dependency {
+                    let a: A
+                    let b: B
+                }
+
+                init(dependency: Dependency) {}
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = InitializerInjectableType(type: type)
+        XCTAssertEqual(injectableType?.name, "Test")
+        XCTAssertEqual(injectableType?.dependencyProperties.count, 2)
+        XCTAssertEqual(injectableType?.dependencyProperties[0].name, "a")
+        XCTAssertEqual(injectableType?.dependencyProperties[0].typeName, "A")
+        XCTAssertEqual(injectableType?.dependencyProperties[1].name, "b")
+        XCTAssertEqual(injectableType?.dependencyProperties[1].typeName, "B")
+    }
+
+    func testNonInjectableType() {
+        let code = """
+            struct Test {
+                struct Dependency {
+                    let a: A
+                    let b: B
+                }
+
+                init(dependency: Dependency) {}
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = InitializerInjectableType(type: type)
+        XCTAssertNil(injectableType)
+    }
+
+    func testClassAssociatedType() {
+        let code = """
+            struct Test: Injectable {
+                class Dependency {
+                    let a: A
+                    let b: B
+                }
+
+                init(dependency: Dependency) {}
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = InitializerInjectableType(type: type)
+        XCTAssertNil(injectableType)
+    }
+
+    func testMissingAssociatedType() {
+        let code = """
+            struct Test: Injectable {
+                init(dependency: Dependency) {}
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = InitializerInjectableType(type: type)
+        XCTAssertNil(injectableType)
+    }
+
+    func testMissingInitializer() {
+        let code = """
+            struct Test: Injectable {
+                struct Dependency {
+                    let a: A
+                    let b: B
+                }
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = InitializerInjectableType(type: type)
+        XCTAssertNil(injectableType)
+    }
+
+    func testWrongTypeInitializer() {
+        let code = """
+            struct Test: Injectable {
+                struct Dependency {
+                    let a: A
+                    let b: B
+                }
+
+                init(dependency: A) {}
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = InitializerInjectableType(type: type)
+        XCTAssertNil(injectableType)
+    }
+}

--- a/Tests/DIGenKitTests/Graph/ProviderMethodTests.swift
+++ b/Tests/DIGenKitTests/Graph/ProviderMethodTests.swift
@@ -23,7 +23,7 @@ final class ProviderMethodTests: XCTestCase {
         let structure = Structure(file: file).substructures.first!
         let type = Type(structure: structure, file: file)!
         let method = ProviderMethod.providerMethods(inResoverType: type).first
-        XCTAssertEqual(method?.name, "provideA(b:c:)")
+        XCTAssertEqual(method?.nameWithoutParameters, "provideA")
         XCTAssertEqual(method?.returnTypeName, "A")
         XCTAssertEqual(method?.parameters.count, 2)
         XCTAssertEqual(method?.parameters[0].name, "b")

--- a/Tests/DIGenKitTests/Graph/ProviderMethodTests.swift
+++ b/Tests/DIGenKitTests/Graph/ProviderMethodTests.swift
@@ -22,7 +22,7 @@ final class ProviderMethodTests: XCTestCase {
         let file = File(contents: code)
         let structure = Structure(file: file).substructures.first!
         let type = Type(structure: structure, file: file)!
-        let method = ProviderMethod.providerMethods(inResoverType: type).first
+        let method = ProviderMethod.providerMethods(inResolverType: type).first
         XCTAssertEqual(method?.nameWithoutParameters, "provideA")
         XCTAssertEqual(method?.returnTypeName, "A")
         XCTAssertEqual(method?.parameters.count, 2)
@@ -42,7 +42,7 @@ final class ProviderMethodTests: XCTestCase {
         let file = File(contents: code)
         let structure = Structure(file: file).substructures.first!
         let type = Type(structure: structure, file: file)!
-        let method = ProviderMethod.providerMethods(inResoverType: type).first
+        let method = ProviderMethod.providerMethods(inResolverType: type).first
         XCTAssertNil(method)
     }
 
@@ -56,7 +56,7 @@ final class ProviderMethodTests: XCTestCase {
         let file = File(contents: code)
         let structure = Structure(file: file).substructures.first!
         let type = Type(structure: structure, file: file)!
-        let method = ProviderMethod.providerMethods(inResoverType: type).first
+        let method = ProviderMethod.providerMethods(inResolverType: type).first
         XCTAssertNil(method)
     }
 
@@ -70,7 +70,7 @@ final class ProviderMethodTests: XCTestCase {
         let file = File(contents: code)
         let structure = Structure(file: file).substructures.first!
         let type = Type(structure: structure, file: file)!
-        let method = ProviderMethod.providerMethods(inResoverType: type).first
+        let method = ProviderMethod.providerMethods(inResolverType: type).first
         XCTAssertNil(method)
     }
 
@@ -84,7 +84,7 @@ final class ProviderMethodTests: XCTestCase {
         let file = File(contents: code)
         let structure = Structure(file: file).substructures.first!
         let type = Type(structure: structure, file: file)!
-        let method = ProviderMethod.providerMethods(inResoverType: type).first
+        let method = ProviderMethod.providerMethods(inResolverType: type).first
         XCTAssertNil(method)
     }
 }

--- a/Tests/DIGenKitTests/Graph/ProviderMethodTests.swift
+++ b/Tests/DIGenKitTests/Graph/ProviderMethodTests.swift
@@ -1,0 +1,90 @@
+//
+//  ProviderMethodTests.swift
+//  DIGenKitTests
+//
+//  Created by Yosuke Ishikawa on 2017/09/22.
+//
+
+import Foundation
+import XCTest
+import SourceKittenFramework
+
+@testable import DIGenKit
+
+final class ProviderMethodTests: XCTestCase {
+    func test() {
+        let code = """
+            protocol Test: Resolver {
+                func provideA(b: B, c: C) -> A
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let method = ProviderMethod.providerMethods(inResoverType: type).first
+        XCTAssertEqual(method?.name, "provideA(b:c:)")
+        XCTAssertEqual(method?.returnTypeName, "A")
+        XCTAssertEqual(method?.parameters.count, 2)
+        XCTAssertEqual(method?.parameters[0].name, "b")
+        XCTAssertEqual(method?.parameters[0].typeName, "B")
+        XCTAssertEqual(method?.parameters[1].name, "c")
+        XCTAssertEqual(method?.parameters[1].typeName, "C")
+    }
+
+    func testNonResolverType() {
+        let code = """
+            protocol Test {
+                func provideA(b: B, c: C) -> A
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let method = ProviderMethod.providerMethods(inResoverType: type).first
+        XCTAssertNil(method)
+    }
+
+    func testMissingReturnType() {
+        let code = """
+            protocol Test: Resolver {
+                func provideA(b: B, c: C)
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let method = ProviderMethod.providerMethods(inResoverType: type).first
+        XCTAssertNil(method)
+    }
+
+    func testStatic() {
+        let code = """
+            protocol Test: Resolver {
+                static func provideA(b: B, c: C) -> A
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let method = ProviderMethod.providerMethods(inResoverType: type).first
+        XCTAssertNil(method)
+    }
+
+    func testWithoutProvidePrefix() {
+        let code = """
+            protocol Test: Resolver {
+                func makeA(b: B, c: C) -> A
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let method = ProviderMethod.providerMethods(inResoverType: type).first
+        XCTAssertNil(method)
+    }
+}


### PR DESCRIPTION
```swift
struct Node {
    enum Declaration {
        case initializerInjectableType(InitializerInjectableType)
        case factoryMethodInjectableType(FactoryMethodInjectableType)
        case providerMethod(ProviderMethod)
        ...
    }

    enum Dependency {
        case node(name: String, node: Node)
        case parameter(Parameter)
    }

    let declaration: Declaration
    let dependencies: [Dependency]
    ...
}
```

Node declarations are represented by `Node.Declaration`. They are instantiated from injectable types and provider methods, and they only know 1 level of dependency graph. Resolved nodes are represented by `Node`. They are artifact of resolving dependency graph, and they know all level of connected dependency graph.