### PR TITLE
Introduce PropertyInjectable and generate inject methods for its conformers

### DIFF
--- a/DIKit.xcodeproj/project.pbxproj
+++ b/DIKit.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		7F3C5B0F1F6D707700842641 /* AppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F3C5B0D1F6D701A00842641 /* AppTests.swift */; };
 		7F467A721F7527A40041CAFB /* PropertyInjectableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F467A711F7527A40041CAFB /* PropertyInjectableType.swift */; };
 		7F467A741F7528870041CAFB /* PropertyInjectableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F467A731F7528870041CAFB /* PropertyInjectableTests.swift */; };
+		7F467A761F752FB70041CAFB /* InjectMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F467A751F752FB70041CAFB /* InjectMethod.swift */; };
+		7F467A781F7534850041CAFB /* GeneratedMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F467A771F7534850041CAFB /* GeneratedMethod.swift */; };
 		7F540C8B1F73F1970045CC12 /* MethodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C8A1F73F1970045CC12 /* MethodTests.swift */; };
 		7F540C8D1F73F2210045CC12 /* PropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C8C1F73F2210045CC12 /* PropertyTests.swift */; };
 		7F540C8F1F73F5340045CC12 /* TypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C8E1F73F5340045CC12 /* TypeTests.swift */; };
@@ -418,6 +420,8 @@
 		7F3C5B0D1F6D701A00842641 /* AppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTests.swift; sourceTree = "<group>"; };
 		7F467A711F7527A40041CAFB /* PropertyInjectableType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyInjectableType.swift; sourceTree = "<group>"; };
 		7F467A731F7528870041CAFB /* PropertyInjectableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyInjectableTests.swift; sourceTree = "<group>"; };
+		7F467A751F752FB70041CAFB /* InjectMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectMethod.swift; sourceTree = "<group>"; };
+		7F467A771F7534850041CAFB /* GeneratedMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedMethod.swift; sourceTree = "<group>"; };
 		7F540C8A1F73F1970045CC12 /* MethodTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MethodTests.swift; sourceTree = "<group>"; };
 		7F540C8C1F73F2210045CC12 /* PropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyTests.swift; sourceTree = "<group>"; };
 		7F540C8E1F73F5340045CC12 /* TypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeTests.swift; sourceTree = "<group>"; };
@@ -810,7 +814,9 @@
 		OBJ_16 /* Graph */ = {
 			isa = PBXGroup;
 			children = (
+				7F467A771F7534850041CAFB /* GeneratedMethod.swift */,
 				OBJ_17 /* ResolveMethod.swift */,
+				7F467A751F752FB70041CAFB /* InjectMethod.swift */,
 				OBJ_19 /* Resolver.swift */,
 				OBJ_18 /* Node.swift */,
 				7F540C931F740C210045CC12 /* InitializerInjectableType.swift */,
@@ -1451,6 +1457,7 @@
 			files = (
 				OBJ_256 /* CodeGenerator.swift in Sources */,
 				7F540C951F740C930045CC12 /* InitializerInjectableType.swift in Sources */,
+				7F467A781F7534850041CAFB /* GeneratedMethod.swift in Sources */,
 				OBJ_257 /* String+Name.swift in Sources */,
 				OBJ_258 /* Structure+Property.swift in Sources */,
 				OBJ_259 /* ResolveMethod.swift in Sources */,
@@ -1462,6 +1469,7 @@
 				OBJ_265 /* Type.swift in Sources */,
 				7F540C9A1F7412E80045CC12 /* FactoryMethodInjectableType.swift in Sources */,
 				7F540C9E1F7414A30045CC12 /* ProviderMethod.swift in Sources */,
+				7F467A761F752FB70041CAFB /* InjectMethod.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DIKit.xcodeproj/project.pbxproj
+++ b/DIKit.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 
 /* Begin PBXBuildFile section */
 		7F3C5B0F1F6D707700842641 /* AppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F3C5B0D1F6D701A00842641 /* AppTests.swift */; };
+		7F467A721F7527A40041CAFB /* PropertyInjectableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F467A711F7527A40041CAFB /* PropertyInjectableType.swift */; };
+		7F467A741F7528870041CAFB /* PropertyInjectableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F467A731F7528870041CAFB /* PropertyInjectableTests.swift */; };
 		7F540C8B1F73F1970045CC12 /* MethodTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C8A1F73F1970045CC12 /* MethodTests.swift */; };
 		7F540C8D1F73F2210045CC12 /* PropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C8C1F73F2210045CC12 /* PropertyTests.swift */; };
 		7F540C8F1F73F5340045CC12 /* TypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F540C8E1F73F5340045CC12 /* TypeTests.swift */; };
@@ -414,6 +416,8 @@
 
 /* Begin PBXFileReference section */
 		7F3C5B0D1F6D701A00842641 /* AppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTests.swift; sourceTree = "<group>"; };
+		7F467A711F7527A40041CAFB /* PropertyInjectableType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyInjectableType.swift; sourceTree = "<group>"; };
+		7F467A731F7528870041CAFB /* PropertyInjectableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyInjectableTests.swift; sourceTree = "<group>"; };
 		7F540C8A1F73F1970045CC12 /* MethodTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MethodTests.swift; sourceTree = "<group>"; };
 		7F540C8C1F73F2210045CC12 /* PropertyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertyTests.swift; sourceTree = "<group>"; };
 		7F540C8E1F73F5340045CC12 /* TypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeTests.swift; sourceTree = "<group>"; };
@@ -673,6 +677,7 @@
 			children = (
 				7F540C971F740FD10045CC12 /* InitializerInjectableTypeTests.swift */,
 				7F540C9B1F7413A70045CC12 /* FactoryMethodInjectableTypeTests.swift */,
+				7F467A731F7528870041CAFB /* PropertyInjectableTests.swift */,
 				7F540C9F1F7416360045CC12 /* ProviderMethodTests.swift */,
 			);
 			path = Graph;
@@ -810,6 +815,7 @@
 				OBJ_18 /* Node.swift */,
 				7F540C931F740C210045CC12 /* InitializerInjectableType.swift */,
 				7F540C991F7412E80045CC12 /* FactoryMethodInjectableType.swift */,
+				7F467A711F7527A40041CAFB /* PropertyInjectableType.swift */,
 				7F540C9D1F7414A30045CC12 /* ProviderMethod.swift */,
 			);
 			path = Graph;
@@ -1421,6 +1427,7 @@
 			files = (
 				7F540C8F1F73F5340045CC12 /* TypeTests.swift in Sources */,
 				OBJ_197 /* ABCDTests.swift in Sources */,
+				7F467A741F7528870041CAFB /* PropertyInjectableTests.swift in Sources */,
 				7F3C5B0F1F6D707700842641 /* AppTests.swift in Sources */,
 				7F540CA01F7416360045CC12 /* ProviderMethodTests.swift in Sources */,
 				7F540C981F740FD10045CC12 /* InitializerInjectableTypeTests.swift in Sources */,
@@ -1450,6 +1457,7 @@
 				OBJ_260 /* Node.swift in Sources */,
 				OBJ_261 /* Resolver.swift in Sources */,
 				OBJ_263 /* Method.swift in Sources */,
+				7F467A721F7527A40041CAFB /* PropertyInjectableType.swift in Sources */,
 				OBJ_264 /* Property.swift in Sources */,
 				OBJ_265 /* Type.swift in Sources */,
 				7F540C9A1F7412E80045CC12 /* FactoryMethodInjectableType.swift in Sources */,

--- a/Sources/DIGenKit/CodeGenerator.swift
+++ b/Sources/DIGenKit/CodeGenerator.swift
@@ -33,9 +33,9 @@ public final class CodeGenerator {
             //
             {% for resolver in resolvers %}
             extension {{ resolver.name }} {
-            {% for resolveMethod in resolver.resolveMethods %}
-                func {{ resolveMethod.name }}({{ resolveMethod.parametersDeclaration }}) -> {{ resolveMethod.returnTypeName }} {
-                    {% for line in resolveMethod.bodyLines %}{{ line }}{% if not forloop.last %}
+            {% for method in resolver.generatedMethods %}
+                func {{ method.name }}({{ method.parametersDeclaration }}) -> {{ method.returnTypeName }} {
+                    {% for line in method.bodyLines %}{{ line }}{% if not forloop.last %}
                     {% endif %}{% endfor %}
                 }
             {% endfor %}

--- a/Sources/DIGenKit/Graph/GeneratedMethod.swift
+++ b/Sources/DIGenKit/Graph/GeneratedMethod.swift
@@ -1,0 +1,16 @@
+//
+//  GeneratedMethod.swift
+//  DIGenKit
+//
+//  Created by Yosuke Ishikawa on 2017/09/22.
+//
+
+protocol GeneratedMethod {
+    var name: String { get }
+    var returnTypeName: String { get }
+    var bodyLines: [String] { get }
+    var parametersDeclaration: String { get }
+}
+
+extension ResolveMethod: GeneratedMethod {}
+extension InjectMethod: GeneratedMethod {}

--- a/Sources/DIGenKit/Graph/Node.swift
+++ b/Sources/DIGenKit/Graph/Node.swift
@@ -9,6 +9,7 @@ struct Node {
     enum Declaration {
         case initializerInjectableType(InitializerInjectableType)
         case factoryMethodInjectableType(FactoryMethodInjectableType)
+        case propertyInjectableType(PropertyInjectableType)
         case providerMethod(ProviderMethod)
 
         struct Dependency {
@@ -22,6 +23,8 @@ struct Node {
                 return type.name
             case .factoryMethodInjectableType(let type):
                 return type.name
+            case .propertyInjectableType(let type):
+                return type.name
             case .providerMethod(let method):
                 return method.returnTypeName
             }
@@ -32,6 +35,8 @@ struct Node {
             case .initializerInjectableType(let type):
                 return type.dependencyProperties.map { Dependency(name: $0.name, typeName: $0.typeName) }
             case .factoryMethodInjectableType(let type):
+                return type.dependencyProperties.map { Dependency(name: $0.name, typeName: $0.typeName) }
+            case .propertyInjectableType(let type):
                 return type.dependencyProperties.map { Dependency(name: $0.name, typeName: $0.typeName) }
             case .providerMethod(let method):
                 return method.parameters.map { Dependency(name: $0.name, typeName: $0.typeName) }

--- a/Sources/DIGenKit/Graph/PropertyInjectableType.swift
+++ b/Sources/DIGenKit/Graph/PropertyInjectableType.swift
@@ -1,0 +1,42 @@
+//
+//  PropertyInjectableType.swift
+//  DIGenKit
+//
+//  Created by Yosuke Ishikawa on 2017/09/22.
+//
+
+import Foundation
+
+struct PropertyInjectableType {
+    let name: String
+    let dependencyProperties: [Property]
+
+    init?(type: Type) {
+        guard
+            type.inheritedTypeNames.contains("PropertyInjectable") ||
+            type.inheritedTypeNames.contains("DIKit.PropertyInjectable") else {
+            // Type is not declared as conformer of 'PropertyInjectableType'.
+            return nil
+        }
+
+        guard let dependencyType = type.nestedTypes.filter({ $0.name == "Dependency" }).first else {
+            // Associated type 'Dependency' declared in 'PropertyInjectableType' is not found.
+            return nil
+        }
+
+        guard dependencyType.kind == .struct else {
+            // Associated type 'Dependency' must be a struct.
+            return nil
+        }
+
+        guard
+            let property = type.properties.filter({ $0.name == "dependency" }).first,
+            !property.isStatic && property.typeName == "Dependency!" else {
+            // Instance property 'dependency' declared in 'PropertyInjectable' is not found.
+            return nil
+        }
+
+        name = type.name
+        dependencyProperties = dependencyType.properties.filter { !$0.isStatic }
+    }
+}

--- a/Sources/DIKit/Injectable.swift
+++ b/Sources/DIKit/Injectable.swift
@@ -14,3 +14,8 @@ public protocol FactoryMethodInjectable {
     associatedtype Dependency
     static func makeInstance(dependency: Dependency) -> Self
 }
+
+public protocol PropertyInjectable {
+    associatedtype Dependency
+    var dependency: Dependency! { get set }
+}

--- a/Sources/DIKit/Injectable.swift
+++ b/Sources/DIKit/Injectable.swift
@@ -15,7 +15,7 @@ public protocol FactoryMethodInjectable {
     static func makeInstance(dependency: Dependency) -> Self
 }
 
-public protocol PropertyInjectable {
+public protocol PropertyInjectable: class {
     associatedtype Dependency
     var dependency: Dependency! { get set }
 }

--- a/Tests/DIGenKitTests/ABCDTests.swift
+++ b/Tests/DIGenKitTests/ABCDTests.swift
@@ -35,6 +35,16 @@ struct C: FactoryMethodInjectable {
 
 struct D {}
 
+class E: PropertyInjectable {
+    struct Dependency {
+        let ea: A
+        let ec: C
+        let eb: B
+    }
+
+    var dependency: Dependency!
+}
+
 protocol ABCDResolver: DIKit.Resolver {
     func provideD() -> D
 }
@@ -68,6 +78,13 @@ final class ABCDTests: XCTestCase {
                     let a = resolveA()
                     let d = resolveD()
                     return C.makeInstance(dependency: .init(ca: a, cd: d))
+                }
+
+                func injectToE(_ e: E) -> Void {
+                    let a = resolveA()
+                    let c = resolveC()
+                    let b = resolveB()
+                    e.dependency = E.Dependency(ea: a, ec: c, eb: b)
                 }
 
             }

--- a/Tests/DIGenKitTests/Graph/PropertyInjectableTests.swift
+++ b/Tests/DIGenKitTests/Graph/PropertyInjectableTests.swift
@@ -1,0 +1,146 @@
+//
+//  PropertyInjectableTests.swift
+//  DIGenKitTests
+//
+//  Created by Yosuke Ishikawa on 2017/09/22.
+//
+
+import Foundation
+import XCTest
+import SourceKittenFramework
+
+@testable import DIGenKit
+
+final class PropertyInjectableTypeTests: XCTestCase {
+    func test() {
+        let code = """
+            struct Test: PropertyInjectable {
+                struct Dependency {
+                    let a: A
+                    let b: B
+                }
+
+                var dependency: Dependency!
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = PropertyInjectableType(type: type)
+        XCTAssertEqual(injectableType?.name, "Test")
+        XCTAssertEqual(injectableType?.dependencyProperties.count, 2)
+        XCTAssertEqual(injectableType?.dependencyProperties[0].name, "a")
+        XCTAssertEqual(injectableType?.dependencyProperties[0].typeName, "A")
+        XCTAssertEqual(injectableType?.dependencyProperties[1].name, "b")
+        XCTAssertEqual(injectableType?.dependencyProperties[1].typeName, "B")
+    }
+
+    func testNonInjectableType() {
+        let code = """
+            struct Test {
+                struct Dependency {
+                    let a: A
+                    let b: B
+                }
+
+                var dependency: Dependency!
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = PropertyInjectableType(type: type)
+        XCTAssertNil(injectableType)
+    }
+
+    func testClassAssociatedType() {
+        let code = """
+            struct Test: PropertyInjectable {
+                class Dependency {
+                    let a: A
+                    let b: B
+                }
+
+                var dependency: Dependency!
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = PropertyInjectableType(type: type)
+        XCTAssertNil(injectableType)
+    }
+
+    func testMissingAssociatedType() {
+        let code = """
+            struct Test: PropertyInjectable {
+                var dependency: Dependency!
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = PropertyInjectableType(type: type)
+        XCTAssertNil(injectableType)
+    }
+
+    func testMissingProperty() {
+        let code = """
+            struct Test: PropertyInjectable {
+                struct Dependency {
+                    let a: A
+                    let b: B
+                }
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = PropertyInjectableType(type: type)
+        XCTAssertNil(injectableType)
+    }
+
+    func testWrongTypeProperty() {
+        let code = """
+            struct Test: PropertyInjectable {
+                struct Dependency {
+                    let a: A
+                    let b: B
+                }
+
+                var dependency: C!
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = PropertyInjectableType(type: type)
+        XCTAssertNil(injectableType)
+    }
+
+    func testNonOptionalProperty() {
+        let code = """
+            struct Test: PropertyInjectable {
+                struct Dependency {
+                    let a: A
+                    let b: B
+                }
+
+                var dependency: Dependency
+            }
+            """
+
+        let file = File(contents: code)
+        let structure = Structure(file: file).substructures.first!
+        let type = Type(structure: structure, file: file)!
+        let injectableType = PropertyInjectableType(type: type)
+        XCTAssertNil(injectableType)
+    }
+}
+


### PR DESCRIPTION
Resolves #3.

```swift
public protocol PropertyInjectable: class {
    associatedtype Dependency
    var dependency: Dependency! { get set }
}
```

Since DIKit doesn't involve instantiation of `PropertyInjectable` conformers, `PropertyInjectable` is only allowed in leaf node of dependency graph.

Unlike other injectable protocols such as `Injectable` or `FactoryMethodInjectable`, `dikitgen` doesn't generates resolve methods for `PropertyInjectable` conformers. Instead of resolver methods, `dikitgen` generates *inject methods* like below:

```swift
// Declaration
class ItemViewController: PropertyInjectable {
    struct Dependency {
        let item: Item
        let apiClient: APIClient
    }

    var dependency: Dependency!
}

// Generated code
extension SomeResolver {
    func injectToItemViewController(_ itemViewController: E, item: Item) -> Void {
        let apiClient = resolveAPIClient()
        itemViewController.dependency = ItemViewController.Dependency(item: item, apiClient: APIClient)
    }
}
```

Inject methods resolve dependencies and set them into target instance.

This method is useful when we work with storyboard segue. Suppose we have list view and move to detail view on tap one of listed item. `prepare(for:sender:)` method is responsible for obtaining selected item and passing it to the destination view controller. Inject method resolves its dependency taking parameters if needed (`item` in the following example).

```swift
override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
    guard
        let itemViewController = segue.destination as? ItemViewController,
        let indexPath = tableView.indexPathsForSelectedRows?.first else {
        return
    }

    let selectedItem = items[indexPath.row]
    resolver.injectToItemViewController(itemViewController, item: selectedItem)
}
```

