### PR TITLE
Fix CYaml/module.modulemap using relative path

### DIFF
--- a/DIKit.xcodeproj/GeneratedModuleMap/CYaml/module.modulemap
+++ b/DIKit.xcodeproj/GeneratedModuleMap/CYaml/module.modulemap
@@ -1,4 +1,4 @@
 module CYaml {
-    umbrella header "/Users/ishkawa/dev/src/github.com/ishkawa/DIKit/.build/checkouts/Yams.git-8068124914099325722/Sources/CYaml/include/CYaml.h"
+    umbrella header "../../../.build/checkouts/Yams.git-8068124914099325722/Sources/CYaml/include/CYaml.h"
     export *
 }


### PR DESCRIPTION
With absolute path I cannot build the project.