### PR TITLE
Use compactMap(_:)

### DIFF
--- a/Sources/DIGenKit/Declarated/ProviderMethod.swift
+++ b/Sources/DIGenKit/Declarated/ProviderMethod.swift
@@ -91,7 +91,7 @@ struct ProviderMethod {
         }
         
         return try type.methods
-            .flatMap { method in
+            .compactMap { method in
                 do {
                     return try ProviderMethod(type: type, method: method)
                 } catch let error as ProviderMethod.Error where error.reason == .providePrefixNotFound {

--- a/Sources/DIGenKit/Structure/Import.swift
+++ b/Sources/DIGenKit/Structure/Import.swift
@@ -14,7 +14,7 @@ struct Import {
     static func imports(from file: File) throws -> [Import] {
         let syntaxMap = try SyntaxMap(file: file)
         let importTokenIndices = syntaxMap.tokens.enumerated()
-            .flatMap { index, token -> Int? in
+            .compactMap { index, token -> Int? in
                 guard token.type == "source.lang.swift.syntaxtype.keyword" else {
                     return nil
                 }
@@ -27,7 +27,7 @@ struct Import {
             }
 
         let importedModuleNames = importTokenIndices
-            .flatMap { index -> String? in
+            .compactMap { index -> String? in
                 let identifierIndex = index + 1
                 guard identifierIndex < syntaxMap.tokens.count else {
                     return nil

--- a/Sources/DIGenKit/Structure/Method.swift
+++ b/Sources/DIGenKit/Structure/Method.swift
@@ -81,7 +81,7 @@ struct Method {
 
         self.name = name
         self.kind = kind
-        self.parameters = structure.substructures.flatMap(Parameter.init)
+        self.parameters = structure.substructures.compactMap(Parameter.init)
         self.file = file
         self.offset = offset
     }

--- a/Sources/DIGenKit/Structure/Type.swift
+++ b/Sources/DIGenKit/Structure/Type.swift
@@ -40,10 +40,10 @@ struct Type {
         self.kind = kind
         self.file = file
         self.offset = offset
-        self.methods = structure.substructures.flatMap { Method(structure: $0, file: file) }
-        self.properties = structure.substructures.flatMap { Property(structure: $0, file: file) }
-        self.nestedTypes = structure.substructures.flatMap { Type(structure: $0, file: file) }
+        self.methods = structure.substructures.compactMap { Method(structure: $0, file: file) }
+        self.properties = structure.substructures.compactMap { Property(structure: $0, file: file) }
+        self.nestedTypes = structure.substructures.compactMap { Type(structure: $0, file: file) }
         self.inheritedTypeNames = (structure[.inheritedtypes] as [[String: SourceKitRepresentable]]?)?
-            .flatMap { $0["key.name"] as? String } ?? []
+            .compactMap { $0["key.name"] as? String } ?? []
     }
 }


### PR DESCRIPTION
# Environment 

- DIKit 0.3.2
- Xcode 9.3.2
    - Swift 4.1.2

# Current behavior

Xcode outputs warnings that flatMap' is deprecated since Swift 4.1.
Using to compactMap(_:) for the case where closure returns an optional value.
