### PR TITLE
Restore build task in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 PREFIX?=/usr/local
 
+build:
+	swift build -c release -Xswiftc -static-stdlib
+
 install: build
 	mkdir -p "$(PREFIX)/bin"
 	cp -f ".build/release/dikitgen" "$(PREFIX)/bin/dikitgen"


### PR DESCRIPTION
The task is used in `make install`.