### PR TITLE
Fix to be able to build macOS farmwork via Carthage

### DIFF
--- a/DIKit.xcodeproj/project.pbxproj
+++ b/DIKit.xcodeproj/project.pbxproj
@@ -722,6 +722,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.ishkawa.DIKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos watchsimulator appletvos appletvsimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -750,6 +751,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.ishkawa.DIKit;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "macosx iphonesimulator iphoneos watchos watchsimulator appletvos appletvsimulator";
 				SWIFT_VERSION = 4.2;


### PR DESCRIPTION
Currently, unavailable to build macOS framework by Carthage.
This problem is caused by [this](https://github.com/Carthage/Carthage/blob/368a13ea6e3e30b22c007cb2be1906f7dc92f055/Source/XCDBLD/BuildArguments.swift#L109).

I changed the `Architectures/Base SDK` to macOS and solved it.