### PR TITLE
Migrate to Swift 5.5

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "jpsim/SourceKitten" ~> 0.23.0
+github "jpsim/SourceKitten" ~> 0.31.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,1 @@
-github "drmohundro/SWXMLHash" "4.8.0"
-github "jpsim/SourceKitten" "0.23.0"
-github "jpsim/Yams" "2.0.0"
+github "jpsim/SourceKitten" "0.31.1"

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,39 +2,21 @@
   "object": {
     "pins": [
       {
-        "package": "Commandant",
-        "repositoryURL": "https://github.com/Carthage/Commandant.git",
-        "state": {
-          "branch": null,
-          "revision": "ab68611013dec67413628ac87c1f29e8427bc8e4",
-          "version": "0.17.0"
-        }
-      },
-      {
-        "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble.git",
-        "state": {
-          "branch": null,
-          "revision": "43304bf2b1579fd555f2fdd51742771c1e4f2b98",
-          "version": "8.0.1"
-        }
-      },
-      {
-        "package": "Quick",
-        "repositoryURL": "https://github.com/Quick/Quick.git",
-        "state": {
-          "branch": null,
-          "revision": "0b4ed6c706dd0cce923b5019a605a9bcc6b1b600",
-          "version": "2.0.0"
-        }
-      },
-      {
         "package": "SourceKitten",
         "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
         "state": {
           "branch": null,
-          "revision": "421a1ec6112b83265b63a163107c9b638dc56e86",
-          "version": "0.23.0"
+          "revision": "558628392eb31d37cb251cfe626c53eafd330df6",
+          "version": "0.31.1"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
+        "state": {
+          "branch": null,
+          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
+          "version": "1.0.3"
         }
       },
       {
@@ -42,8 +24,8 @@
         "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
         "state": {
           "branch": null,
-          "revision": "0d6bb315528888edde0dafe93564f074669c44e9",
-          "version": "4.8.0"
+          "revision": "9183170d20857753d4f331b0ca63f73c60764bf3",
+          "version": "5.0.2"
         }
       },
       {
@@ -51,8 +33,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
-          "version": "2.0.0"
+          "revision": "9ff1cc9327586db4e0c8f46f064b6a82ec1566fa",
+          "version": "4.0.6"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
                 "DIKit",
                 .product(name: "SourceKittenFramework", package: "SourceKitten"),
             ]),
-    .target(name: "dikitgen", dependencies: ["DIGenKit"]),
+    .executableTarget(name: "dikitgen", dependencies: ["DIGenKit"]),
     .testTarget(name: "DIGenKitTests", dependencies: ["DIGenKit"])
   ],
   swiftLanguageVersions: [.v5]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,11 @@ let package = Package(
   ],
   targets: [
     .target(name: "DIKit"),
-    .target(name: "DIGenKit", dependencies: ["DIKit", "SourceKittenFramework"]),
+    .target(name: "DIGenKit",
+            dependencies: [
+                "DIKit",
+                .product(name: "SourceKittenFramework", package: "SourceKitten"),
+            ]),
     .target(name: "dikitgen", dependencies: ["DIGenKit"]),
     .testTarget(name: "DIGenKitTests", dependencies: ["DIGenKit"])
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     .library(name: "DIGenKit", targets: ["DIGenKit"])
   ],
   dependencies: [
-    .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.23.0")
+    .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.31.1"),
   ],
   targets: [
     .target(name: "DIKit"),

--- a/Sources/DIGenKit/Structure/Import.swift
+++ b/Sources/DIGenKit/Structure/Import.swift
@@ -20,8 +20,8 @@ struct Import {
                 }
 
                 let view = file.contents.utf8
-                let startIndex = view.index(view.startIndex, offsetBy: Int(token.offset))
-                let endIndex = view.index(startIndex, offsetBy: Int(token.length))
+                let startIndex = view.index(view.startIndex, offsetBy: Int(token.offset.value))
+                let endIndex = view.index(startIndex, offsetBy: Int(token.length.value))
                 let value = String(view[startIndex..<endIndex])!
                 return value == "import" ? index : nil
             }
@@ -39,8 +39,8 @@ struct Import {
                 }
 
                 let view = file.contents.utf8
-                let startIndex = view.index(view.startIndex, offsetBy: Int(token.offset))
-                let endIndex = view.index(startIndex, offsetBy: Int(token.length))
+                let startIndex = view.index(view.startIndex, offsetBy: Int(token.offset.value))
+                let endIndex = view.index(startIndex, offsetBy: Int(token.length.value))
                 return String(view[startIndex..<endIndex])!
             }
 

--- a/Sources/DIKit/Injectable.swift
+++ b/Sources/DIKit/Injectable.swift
@@ -15,7 +15,7 @@ public protocol FactoryMethodInjectable {
     static func makeInstance(dependency: Dependency) -> Self
 }
 
-public protocol PropertyInjectable: class {
+public protocol PropertyInjectable: AnyObject {
     associatedtype Dependency
     var dependency: Dependency! { get set }
 }


### PR DESCRIPTION
- Bump swift-tools-version to 5.5
- Bump [jpsim/SourceKitten](https://github.com/jpsim/SourceKitten)
  - Fix for https://github.com/jpsim/SourceKitten/pull/639
- Others
  - https://forums.swift.org/t/se-0294-declaring-executable-targets-in-package-manifests/42404/11
  - https://github.com/apple/swift-evolution/blob/master/proposals/0156-subclass-existentials.md#class-and-anyobject

## Environment

- Xcode 13.2.1 (13C100)